### PR TITLE
Add Coverage for Unit and e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,35 @@ orbs:
   node: circleci/node@3.0.0
 jobs:
   test:
-    executor:
-      name: node/default
+    machine: true
     steps:
       - checkout
+      - run:
+          name: 'Install Project Node'
+          command: |
+            set +x
+            source ~/.bashrc
+
+            nvm install 12.18.1
+            NODE_DIR=$(dirname $(which node))
+            echo "export PATH=$NODE_DIR:\$PATH" >> $BASH_ENV
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - persist_to_workspace:
           root: .
           paths:
             - .
-      - node/install:
-          node-version: 12.16.2
-      - node/install-packages
       - run:
-          command: npm test
+          command: npm install
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - node_modules
+      - run:
+          command: npm run test:cov
+      - run:
+          name: codecov
+          command: bash <(curl -s https://codecov.io/bash)
   build-and-push:
     environment:
       IMAGE_NAME: sdevilcry/vincelivemix

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "lint:fix": "npm rum lint -- --fix",
     "prettier": "prettier -l '{src,test}/**/*.{ts,yml,yaml,json,md}'",
     "prettier:write": "prettier --write '{src,test}/**/*.{ts,yml,yaml,json,md}'",
-    "test": "jest",
+    "test": "jest && npm run test:e2e",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test:cov": "jest --coverage && npm run test:e2e:cov",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json  --runInBand",
+    "test:e2e:cov": "jest --coverage --config ./test/jest-e2e.json  --runInBand",
     "typeorm:dev": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js --config src/config/typeorm-cli.config.ts",
     "typeorm:prod": "./node_modules/typeorm/cli.js --config dist/config/typeorm-cli.config.js",
     "migration:generate": "npm run typeorm:dev migration:generate -- -n",
@@ -93,7 +94,7 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "../coverage/unit",
     "testEnvironment": "node"
   }
 }

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -15,15 +15,15 @@ export class ConfigModule {
   public static forRoot(): DynamicModule {
     const configs = [
       new DatabaseConfigDto({
-        host: process.env.POSTGRES_HOST,
-        port: Number(process.env.POSTGRES_PORT),
-        user: process.env.POSTGRES_USER,
-        password: process.env.POSTGRES_PASSWORD,
-        database: process.env.POSTGRES_DB,
+        host: process.env.POSTGRES_HOST || 'localhost',
+        port: Number(process.env.POSTGRES_PORT) || 5432,
+        user: process.env.POSTGRES_USER || 'postgres',
+        password: process.env.POSTGRES_PASSWORD || 'postgres',
+        database: process.env.POSTGRES_DB || 'vincelivemix',
         synchronize: process.env.TYPEORM_SYNCHRONIZE === 'true',
         autoRunMigration: process.env.TYPEORM_AUTO_RUN_MIGRATION === 'true',
         logging: process.env.TYPEORM_LOGGING === 'true',
-        retriesNumber: Number(process.env.TYPEORM_RETRIES_NUMBER),
+        retriesNumber: Number(process.env.TYPEORM_RETRIES_NUMBER) || 1,
       }),
       new AuthConfigDto({
         // Multi line is a pain in the ass to  deal with... so for development, I use this default one
@@ -56,14 +56,15 @@ BQaTCQKBgQCOSpjGM882KHjC/Mr3e8BKii1BAR1aEI0lDyAHD90ozi9sA6xAh7tM
 wccmqrtok3rcgaxkEa44lwIg/QfODmOiZ/sQbVj3srgvUEs85or1cX82cwbBXBxK
 Jg31gSVi79LcB/+W7BezGtex7Ru6rTja6DJalM0HzD5s3OsLWV2h+Q==
 -----END RSA PRIVATE KEY-----`,
-        lifetime: Number(process.env.AUTH_LIFETIME_SESSION),
-        superAdminUser: process.env.AUTH_ADMIN_USER_LOGIN,
-        superAdminPassword: process.env.AUTH_ADMIN_USER_PASSWORD,
+        lifetime: Number(process.env.AUTH_LIFETIME_SESSION) || 3600,
+        superAdminUser: process.env.AUTH_ADMIN_USER_LOGIN || 'superuser',
+        superAdminPassword:
+          process.env.AUTH_ADMIN_USER_PASSWORD || 'superpassword',
         isSuperAdminUserEnabled:
           Boolean(process.env.AUTH_ADMIN_USER_ENABLED) === true,
       }),
       new WebServerConfigDto({
-        port: Number(process.env.APP_PORT),
+        port: Number(process.env.APP_PORT) || 8080,
       }),
     ];
 

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,11 +1,20 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "../",
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "testMatch": [
+    "**/test/**/*.e2e-spec.ts"
+  ],
+  "coverageDirectory": "<rootDir>/coverage/e2e",
+  "collectCoverageFrom": [
+    "<rootDir>/src/**/*.ts",
+    "!<rootDir>/src/**/*.spec.ts",
+    "!<rootDir>/src/**/*.fixture.ts",
+    "!<rootDir>/src/main.ts"
+  ],
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "globalSetup": "./setup.ts",
-  "globalTeardown": "./teardown.ts"
+  "globalSetup": "<rootDir>/src/../test/setup.ts",
+  "globalTeardown": "<rootDir>/src/../test/teardown.ts"
 }


### PR DESCRIPTION
Coverage has been added combining unit and e2e tests.

As a note, I added default config value because it was not right during CI to add all of them by hand in the env project. So the even if .env is missing for a developer or even if the settings are not updated in production, it will have a default value.

