### PR TITLE
Ignore Migrations coverage and clean unused code

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,13 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "coverageDirectory": "../coverage/unit",
+    "collectCoverageFrom": [
+      "<rootDir>/src/**/*.ts",
+      "!<rootDir>/src/**/*.spec.ts",
+      "!<rootDir>/src/**/*.fixture.ts",
+      "!<rootDir>/src/main.ts",
+      "!<rootDir>/migrations/**"
+    ],
     "testEnvironment": "node"
   }
 }

--- a/src/shared/constants/postgres.constant.ts
+++ b/src/shared/constants/postgres.constant.ts
@@ -1,1 +1,0 @@
-export const UNIQUE_VIOLATION_CODE_ERROR = '23505';

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -10,7 +10,8 @@
     "<rootDir>/src/**/*.ts",
     "!<rootDir>/src/**/*.spec.ts",
     "!<rootDir>/src/**/*.fixture.ts",
-    "!<rootDir>/src/main.ts"
+    "!<rootDir>/src/main.ts",
+    "!<rootDir>/src/migrations/**"
   ],
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"


### PR DESCRIPTION
Testing migrations is not useful because we Implicitly test them when running e2e tests. Those tests, while creating the app with `createTestingModule` and calling the `init` will execute the migrations from 0.